### PR TITLE
Fixing breaking change to Concurrent::Future in Crystal 0.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Version 0.3
 
-_NOTE_ This version Crystal > 0.35
+_NOTE_ This requires version Crystal > 0.35
 
-1. Crystal team has move Concurrent::Future to community-future shard, and remove functionality from standard library in Crystal version 0.35
+1. Crystal team has moved Concurrent::Future to community-future shard, and removed functionality from standard library in Crystal version 0.35
 2. Discussion is here: https://github.com/crystal-lang/crystal/pull/9093
-3. This update lucky-cluster to be compatible with the change
+3. This updates lucky-cluster to be compatible with the change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## Version 0.3
+
+_NOTE_ This version Crystal > 0.35
+
+1. Crystal team has move Concurrent::Future to community-future shard, and remove functionality from standard library in Crystal version 0.35
+2. Discussion is here: https://github.com/crystal-lang/crystal/pull/9093
+3. This update lucky-cluster to be compatible with the change

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: lucky-cluster
-version: 0.2.0
+version: 0.3.0
 
 authors:
   - Jeremy Woertink <jeremywoertink@gmail.com>
@@ -7,3 +7,7 @@ authors:
 crystal: 0.29.0
 
 license: MIT
+
+dependencies:
+  future:
+    github: crystal-community/future.cr

--- a/src/lucky-cluster.cr
+++ b/src/lucky-cluster.cr
@@ -4,12 +4,12 @@ module Lucky
 
   class Cluster < ::AppServer
     VERSION = "0.3.0"
-    private getter processes : Array(Concurrent::Future(Nil))
+    private getter processes : Array(Future::Compute(Nil))
     private getter reuse_port : Bool
     property threads : Int32 = 1
 
     def initialize
-      @processes = [] of Concurrent::Future(Nil)
+      @processes = [] of Future::Compute(Nil)
       @reuse_port = true
       super
     end

--- a/src/lucky-cluster.cr
+++ b/src/lucky-cluster.cr
@@ -1,7 +1,9 @@
+require "future"
+
 module Lucky
 
   class Cluster < ::AppServer
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
     private getter processes : Array(Concurrent::Future(Nil))
     private getter reuse_port : Bool
     property threads : Int32 = 1


### PR DESCRIPTION
1. Crystal team has move Concurrent::Future to community-future shard, and remove functionality from standard library in Crystal version 0.35
2. Discussion is here: https://github.com/crystal-lang/crystal/pull/9093
3. This update lucky-cluster to be compatible with the change

On a side note, Amber::Cluster actually spawns separate processes via Process.fork - worth looking into.