### PR TITLE
Update docs to reflect System.cpu_count returning an Int64

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ app_server = Lucky::Cluster.new
 # This boots a new process for each thread.
 app_server.threads = ENV.fetch("MAX_THREADS") { "10" }.to_i
 # You can also use this:
-# app_server.threads = System.cpu_count
+# app_server.threads = System.cpu_count.to_i32
 
 app_server.listen
 ```


### PR DESCRIPTION
Fixes this issue:

```
web          | In src/start_server.cr:12:29
web          | 
web          |  12 | app_server.threads = System.cpu_count
web          |                                   ^--------
web          | Error: expected argument #1 to 'Lucky::Cluster#threads=' to be Int32, not Int64
```

Maybe the proper fix is to change `app_server.threads` type to accept Int64 since `System.cpu_count` is returning that. Thoughts?